### PR TITLE
Homepage Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The rules checked in this module are:
 * **description.length** - The length of the content in the description meta tag was more than 160
 * **description.missing** - No description meta tags found on the page
 * **description.location** - Description meta tag was found, but not in the head of the page
+* **homepage** - Returned when a common of alias of the homepage is also being served with a 200, which would indicate duplicate content
 * **duplicate.protocol** - Both the http:// and https:// versions of the page are presenting content
 * **duplicate.protocol.error** - Either the http:// or https:// version of the page returned a status code between 400 and 600
 * **duplicate.protocol.http** - Returned when http:// is not configured while running a https:// page.

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -1,0 +1,29 @@
+Due to various configs of web servers, the homepage of a site could possibly be accessed using numerous alias. 
+
+For SEO reasons (and to avoid duplicate content) these alias should ideally redirect to the intended homepage or just returrn a error.
+
+It should be noted most search engines like [https://google.com](Google) do handle these edges cases as they see fit but to avoid unexpected behaviour is is recommended to take control to avoid confusion and avoid wasted server load.
+
+# How do I fix this ?
+
+Only one of the following may be considered the "true" homepage and all other alias listed should be redirected to the selected homepage:
+
+* `/`
+* `/index.php`
+* `/home.php`
+* `/default.php`
+* `/index.html`
+* `/home.html`
+* `/default.html`
+* `/index.aspx`
+* `/home.aspx`
+* `/default.aspx`
+
+This will ensure the site is optimised for search engines like [https://google.com](Google) when checking the website.
+
+That will listen on port 80 for HTTP requests and 301 redirect them to HTTPS instead. Your users will now be more secure and love you for it. Good job.
+
+# Resources
+
+* [htaccess remove index.php from url](http://stackoverflow.com/questions/4365129/htaccess-remove-index-php-from-url)
+* [nginx rewrite rules](http://nginx.org/en/docs/http/converting_rewrite_rules.html)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,18 @@
+module.exports = exports = {
+
+  VARIATIONS: [
+
+    '/',
+    '/index.php',
+    '/home.php',
+    '/default.php',
+    '/index.html',
+    '/home.html',
+    '/default.html',
+    '/index.aspx',
+    '/home.aspx',
+    '/default.aspx'
+
+  ]
+
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ module.exports = exports = [
   require('./rules/description'),
   require('./rules/canonical'),
   require('./rules/canonical.link'),
+  require('./rules/homepage'),
   require('./rules/robots'),
   require('./rules/protocol')
 

--- a/lib/rules/homepage.js
+++ b/lib/rules/homepage.js
@@ -4,6 +4,7 @@ const S             = require('string');
 const async         = require('async');
 const request       = require('request');
 const _             = require('underscore');
+const constants     = require('../constants');
 
 // stub functions that will check for testing data first, 
 // before doing a actual request over the network
@@ -44,20 +45,7 @@ module.exports = exports = function(payload, fn) {
   var uri       = url.parse(data.url);
 
   // variations we will be checking of the homepage
-  const variations = [
-
-    '/',
-    '/index.php',
-    '/home.php',
-    '/default.php',
-    '/index.html',
-    '/home.html',
-    '/default.html',
-    '/index.aspx',
-    '/home.aspx',
-    '/default.aspx'
-
-  ];
+  const variations = constants.VARIATIONS;
 
   // get a cleaned pathname
   var pathname = S(uri.path || '').trim().toLowerCase().s;
@@ -106,15 +94,19 @@ module.exports = exports = function(payload, fn) {
 
     }, function(err, response) {
 
+      // get the status code
+      var statuscode = (response || {}).statusCode;
+
       // check if we got a 200
-      if((response || {}).statusCode === 200) {
+      if(statuscode >= 200 && 
+          statuscode < 300) {
 
         // this is baaaaad, register the rule
         payload.addRule({
 
           type:         'error',
           message:      'Common alias of homepage should not also be serving',
-          key:          'homepages'
+          key:          'homepage'
 
         }, {
 

--- a/lib/rules/homepage.js
+++ b/lib/rules/homepage.js
@@ -1,0 +1,142 @@
+// load in the required modules
+const url           = require('url');
+const S             = require('string');
+const async         = require('async');
+const request       = require('request');
+const _             = require('underscore');
+
+// stub functions that will check for testing data first, 
+// before doing a actual request over the network
+var doRequest = function(payload, options, fn) {
+
+  // params to send back
+  var data      = payload.getData();
+
+  // check if we got testing data
+  if(data.testingPresentError)
+    return fn(new Error());
+
+  // check if we got testing data
+  if(data.testingStatusCode)
+    return fn(null, {
+
+      statusCode: 1 * data.testingStatusCode,
+      request: {
+
+        uri: url.parse(data.testingRequestUrl)
+
+      }
+
+    }, '');
+
+  // check if we are not running 2 versions of the same page
+  request(options, fn);
+
+};
+
+// expose the items
+module.exports = exports = function(payload, fn) {
+
+  // params to send back
+  var data      = payload.getData();
+
+  // parse the current url
+  var uri       = url.parse(data.url);
+
+  // variations we will be checking of the homepage
+  const variations = [
+
+    '/',
+    '/index.php',
+    '/home.php',
+    '/default.php',
+    '/index.html',
+    '/home.html',
+    '/default.html',
+    '/index.aspx',
+    '/home.aspx',
+    '/default.aspx'
+
+  ];
+
+  // get a cleaned pathname
+  var pathname = S(uri.path || '').trim().toLowerCase().s;
+
+  // right check if this is the homepage
+  if(variations.indexOf( pathname ) === -1) {
+
+    // debugging
+    payload.debug('Skipping as ' + uri.pathname + ' != /')
+
+    // finish strong
+    return fn(null);
+    
+  }
+
+  // loop in async and do a HEAD request to them all
+  // checking if any one of them returns a 200 which
+  // would indicate that the page is serving
+  async.each(variations, function(variation, cb) {
+
+    // check if it does not match the current page
+    if(variation === pathname) {
+
+      // debugging
+      payload.debug('Skipping as ' + variation + ' matches the current page - ' + pathname);
+
+      // done
+      return cb(null);
+
+    }
+
+    // create the current variation url to check
+    var href = url.format( _.extend({}, uri, {
+
+      path:       variation,
+      pathname:   null,
+      query:      null
+
+    }) );
+
+    // do the request
+    doRequest(payload, {
+
+      url:      href,
+      timeout:  5 * 1000
+
+    }, function(err, response) {
+
+      // check if we got a 200
+      if((response || {}).statusCode === 200) {
+
+        // this is baaaaad, register the rule
+        payload.addRule({
+
+          type:         'error',
+          message:      'Common alias of homepage should not also be serving',
+          key:          'homepages'
+
+        }, {
+
+          message:      '$ should be redirect to $',
+          identifiers:  [ href, url.format(uri) ],
+          display:      'url',
+          url:          href
+
+        });
+
+      }
+
+      // done
+      cb(null);
+
+    });
+
+  }, function() {
+
+    // done
+    fn(null);
+
+  });
+
+};

--- a/lib/rules/homepage.js
+++ b/lib/rules/homepage.js
@@ -31,7 +31,7 @@ var doRequest = function(payload, options, fn) {
     }, '');
 
   // check if we are not running 2 versions of the same page
-  request(options, fn);
+  request.head(options, fn);
 
 };
 
@@ -90,7 +90,9 @@ module.exports = exports = function(payload, fn) {
     doRequest(payload, {
 
       url:      href,
-      timeout:  5 * 1000
+      timeout:  5 * 1000,
+      method:   'HEAD',
+      type:     'HEAD'
 
     }, function(err, response) {
 

--- a/test/homepage.js
+++ b/test/homepage.js
@@ -1,0 +1,162 @@
+// modules
+const assert        = require('assert');
+const _             = require('underscore');
+const fs            = require('fs');
+const passmarked    = require('passmarked');
+const testFunc      = require('../lib/rules/homepage');
+const constants     = require('../lib/constants');
+
+// handle the settings
+describe('homepage', function() {
+
+  // variations we will be checking of the homepage
+  const variations = constants.VARIATIONS;
+
+  // loop and add a test for each
+  for(var i = 0; i < variations.length; i++) {
+
+    // handle the error output
+    it('Should not report a error if ' + variations[i] + ' returns statuscode < 200 || > 300 while testing /about', function(done) {
+
+      // handle the payload
+      var payload = passmarked.createPayload({
+
+        url:                'https://example.com/about',
+        testingStatusCode:  302,
+        testingRequestUrl:  'http://example.com'
+
+      }, null, '')
+
+      // run the rules
+      testFunc(payload, function(err) {
+
+        // check for a error
+        if(err)
+          assert.fail('Was not expecting a error');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // check
+        var rule = _.find(rules, function(item) {
+
+          return item.key == 'homepage';
+
+        });
+
+        // check if we found it
+        if(rule)
+          assert.fail('Was was expecting a rule to return');
+
+        // done
+        done();
+
+      });
+
+    });
+
+  }
+
+  // loop and add a test for each
+  for(var i = 0; i < variations.length; i++) {
+
+    for(var a = 0; a < variations.length; a++) {
+
+      var variationToCheck = variations[i];
+
+      // handle the error output
+      it('Should not report a error if ' + variations[a] + ' returns statuscode < 200 || > 300 while testing ' + variations[i], function(done) {
+
+        // handle the payload
+        var payload = passmarked.createPayload({
+
+          url:                'https://example.com' + variationToCheck,
+          testingStatusCode:  302,
+          testingRequestUrl:  'http://example.com'
+
+        }, null, '')
+
+        // run the rules
+        testFunc(payload, function(err) {
+
+          // check for a error
+          if(err)
+            assert.fail('Was not expecting a error');
+
+          // get the rules
+          var rules = payload.getRules();
+
+          // check
+          var rule = _.find(rules, function(item) {
+
+            return item.key == 'homepage';
+
+          });
+
+          // check if we found it
+          if(rule)
+            assert.fail('Was was expecting a rule to return');
+
+          // done
+          done();
+
+        });
+
+      });
+
+    }
+
+  }
+
+  // loop and add a test for each
+  for(var i = 0; i < variations.length; i++) {
+
+    for(var a = 0; a < variations.length; a++) {
+
+      var variationToCheck = variations[i];
+
+      // handle the error output
+      it('Should report a error if ' + variations[a] + ' returns statuscode >= 200 || < 300 while testing ' + variations[i], function(done) {
+
+        // handle the payload
+        var payload = passmarked.createPayload({
+
+          url:                'https://example.com' + variationToCheck,
+          testingStatusCode:  200,
+          testingRequestUrl:  'http://example.com'
+
+        }, null, '')
+
+        // run the rules
+        testFunc(payload, function(err) {
+
+          // check for a error
+          if(err)
+            assert.fail('Was not expecting a error');
+
+          // get the rules
+          var rules = payload.getRules();
+
+          // check
+          var rule = _.find(rules, function(item) {
+
+            return item.key == 'homepage';
+
+          });
+
+          // check if we found it
+          if(!rule)
+            assert.fail('Was was expecting a rule to return');
+
+          // done
+          done();
+
+        });
+
+      });
+
+    }
+
+  }
+
+});


### PR DESCRIPTION
Added the homepage checks as per #4. The rule only checks these alias when on a known "homepage" from the following list:
- index.php
- home.php
- default.php
- index.html
- home.html
- default.html
- index.aspx
- home.aspx
- default.aspx

When the tested url is one of these listed paths, a HEAD request is sent out to all the other listed alias. If the tested HEAD returns >= 200 or < 300, the rule is given as a `error`.
