### PR TITLE
Sitemap Check / Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '6.2'
   - '5.1'
   - '4.2'
-  - '0.12'
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The rules checked in this module are:
 * **robots.msnbotmedia** - The bot from Bing that indexes images and videos to be searched has been blocked.
 * **robots.adidxbot** - The bot that Bing uses to crawl for ad quality purposes.
 * **robots.yahoo** - The bot from Yahoo that indexes sites to be searched has been blocked.
+* **sitemap.format** - The sitemap.xml returned was not text/xml or application/xml
+* **sitemap.invalid** - The returned sitemap.xml could not be parsed as XML
+* **sitemap.schema** - The defined schema for sitemap.xml was not valid according to spec
+* **sitemap.prolog** - The sitemap has either no prolog or a misconfigured prolog specified
 
 ## Robots
 

--- a/docs/sitemap.empty.md
+++ b/docs/sitemap.empty.md
@@ -1,0 +1,27 @@
+Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+
+These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`.
+
+The sitemap returned by the website was empty, nada, nothing ... After parsing the file no structure could be found, this indicates a empty file. Meaning any search engines trying to parse the file will not find any urls and might even mark the sitemap parsing as a failure.
+
+# How do I fix this ?
+
+Look at defining at least the bare minimum for some structure in the file, while you're at it go ahead and add some urls too.
+
+Basic structures of sitemaps as are:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <url>
+      <loc>http://www.example.com/</loc>
+   </url>
+   <url>
+      <loc>http://www.example.com/about</loc>
+   </url>
+</urlset> 
+```
+
+# Resources
+
+* [Sitemaps XML format](http://www.sitemaps.org/protocol.html)

--- a/docs/sitemap.empty.md
+++ b/docs/sitemap.empty.md
@@ -8,7 +8,7 @@ The sitemap returned by the website was empty, nada, nothing ... After parsing t
 
 Look at defining at least the bare minimum for some structure in the file, while you're at it go ahead and add some urls too.
 
-Basic structures of sitemaps as are:
+The basic structure of a sitemap is:
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/sitemap.empty.md
+++ b/docs/sitemap.empty.md
@@ -1,8 +1,8 @@
-Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+Sitemaps (although not that widely used anymore but still a valid standard) allow site owners to give search engines lists of URLs that might be hard to find while doing a normal crawl of the website.
 
-These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`.
+These sitemaps must be an XML file on the root of the site, namely `/sitemap.xml`.
 
-The sitemap returned by the website was empty, nada, nothing ... After parsing the file no structure could be found, this indicates a empty file. Meaning any search engines trying to parse the file will not find any urls and might even mark the sitemap parsing as a failure.
+The sitemap returned by the website was empty, nada, nothing ... After parsing the file no structure could be found, this indicates an empty file. Meaning any search engines trying to parse the file will not find any URLs and might even mark the sitemap parsing as a failure.
 
 # How do I fix this ?
 

--- a/docs/sitemap.format.md
+++ b/docs/sitemap.format.md
@@ -1,6 +1,6 @@
-Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+Sitemaps (although not that widely used anymore but still a valid standard) allow site owners to give search engines lists of URLs that might be hard to find while doing a normal crawl of the website.
 
-These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`. Common mistakes around these files involve websites that do not have these files added and return either a full page or content other than XML.
+These sitemaps must be an XML file on the root of the site, namely `/sitemap.xml`. Common mistakes around these files involve websites that do not have these files added and return either a full page or content other than XML.
 
 These urls are expected to return either `application/xml` or `text/xml`, anything else indicates that the server is not handling the request correct and/or the file is simply not present and the server is falling back to a full page load. This leads to wasted server time, although minimal.
 

--- a/docs/sitemap.format.md
+++ b/docs/sitemap.format.md
@@ -1,0 +1,15 @@
+Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+
+These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`. Common mistakes around these files involve websites that do not have these files added and return either a full page or content other than XML.
+
+These urls are expected to return either `application/xml` or `text/xml`, anything else indicates that the server is not handling the request correct and/or the file is simply not present and the server is falling back to a full page load. This leads to wasted server time, although minimal.
+
+# How do I fix this ?
+
+Ensure that the sitemap listed at `/sitemap.xml` that is returning a 200, is either defined or updated to return a code other than 200 to show that the file is not present.
+
+The request is expected to be returned as either `application/xml` or `text/xml`.
+
+# Resources
+
+* [Sitemaps XML format](http://www.sitemaps.org/protocol.html)

--- a/docs/sitemap.invalid.md
+++ b/docs/sitemap.invalid.md
@@ -1,0 +1,12 @@
+Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+
+These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`. The sitemap listed for the website could not be parsed as valid XML, which could lead to unexpected and even urls not being crawled.
+
+# How do I fix this ?
+
+Ensure that the returned XML file from `/sitemap.xml` contains valid XML that can be used, see [www.xmlvalidation.com/](https://www.xmlvalidation.com/) for an quick tool to test for valid XML.
+
+# Resources
+
+* [Sitemaps XML format](http://www.sitemaps.org/protocol.html)
+* [Validate XML](https://www.xmlvalidation.com/)

--- a/docs/sitemap.invalid.md
+++ b/docs/sitemap.invalid.md
@@ -1,6 +1,6 @@
-Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+Sitemaps (although not that widely used anymore but still a valid standard) allow site owners to give search engines lists of URLs that might be hard to find while doing a normal crawl of the website.
 
-These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`. The sitemap listed for the website could not be parsed as valid XML, which could lead to unexpected and even urls not being crawled.
+These sitemaps must be an XML file on the root of the site, namely `/sitemap.xml`. The sitemap listed for the website could not be parsed as valid XML, which could lead to unexpected and even urls not being crawled.
 
 # How do I fix this ?
 

--- a/docs/sitemap.prolog.md
+++ b/docs/sitemap.prolog.md
@@ -1,0 +1,28 @@
+Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+
+These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml` that start with an valid prolog on the first line:
+
+```
+<?xml version="1.0" encoding="UTF-8" ?>
+
+..rest of sitemap ..
+
+```
+
+> Ideally with computers, you'd be very explicit with output and much more relaxed with input.
+
+The reason for the prolog (although optional) is that sitemaps with a explicit encoding remove any change of unexpected behaviour that might cause urls to be indexed wrong with unintended characters.
+
+# How do I fix this ?
+
+Ensure that the first line of the XML file:
+
+* Starts with `<?xml`
+* Contains the `version="1.0"` attribute
+* Contains a `encoding="UTF-8"` attribute (note UTF-8 can be changed to another encoding if required)
+* Ends with `?>`
+
+# Resources
+
+* [Sitemaps XML format](http://www.sitemaps.org/protocol.html)
+* [What Content-Type value should I send for my XML sitemap?](http://stackoverflow.com/questions/3272534/what-content-type-value-should-i-send-for-my-xml-sitemap)

--- a/docs/sitemap.prolog.md
+++ b/docs/sitemap.prolog.md
@@ -1,6 +1,6 @@
-Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+Sitemaps (although not that widely used anymore but still a valid standard) allow site owners to give search engines lists of URLs that might be hard to find while doing a normal crawl of the website.
 
-These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml` that start with an valid prolog on the first line:
+These sitemaps must be an XML file on the root of the site, namely `/sitemap.xml` that start with an valid prolog on the first line:
 
 ```
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -11,7 +11,7 @@ These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml`
 
 > Ideally with computers, you'd be very explicit with output and much more relaxed with input.
 
-The reason for the prolog (although optional) is that sitemaps with a explicit encoding remove any change of unexpected behaviour that might cause urls to be indexed wrong with unintended characters.
+The reason for the prolog (although optional) is that sitemaps with an explicit encoding removes any change of unexpected behaviour that might cause URLs to be indexed wrong with unintended characters.
 
 # How do I fix this ?
 
@@ -19,7 +19,7 @@ Ensure that the first line of the XML file:
 
 * Starts with `<?xml`
 * Contains the `version="1.0"` attribute
-* Contains a `encoding="UTF-8"` attribute (note UTF-8 can be changed to another encoding if required)
+* Contains an `encoding="UTF-8"` attribute (note UTF-8 can be changed to another encoding if required)
 * Ends with `?>`
 
 # Resources

--- a/docs/sitemap.schema.md
+++ b/docs/sitemap.schema.md
@@ -1,0 +1,58 @@
+Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+
+These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml` that conform to the standard laid out by [Sitemaps XML format](http://www.sitemaps.org/protocol.html). 
+
+Valid sitemaps would appear as follows (for a example):
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+   <url>
+
+      <loc>http://www.example.com/</loc>
+
+      <lastmod>2005-01-01</lastmod>
+
+      <changefreq>monthly</changefreq>
+
+      <priority>0.8</priority>
+
+   </url>
+
+   <url>
+
+      <loc>http://www.example.com/</loc>
+
+      <lastmod>2005-01-01</lastmod>
+
+      <changefreq>monthly</changefreq>
+
+      <priority>0.8</priority>
+
+   </url>
+
+</urlset> 
+
+with the following options, that are either required or optional:
+
+* loc (required) - The absolute url for the page that is intended to be crawled
+* lastmod (optional) - The last modified date of this url in the format `YYYY-MM-DD`, search engines may or may not use this property as per their own discretion.
+* changefreq (optional) - Gives search engines a **hint** as to how frequently this page is updated, possible values include:
+** `always` - Indicates document that change everytime they are accessed
+** `hourly` - Indicates documents could be changed every hour
+** `daily` - Indicates documents could be changed every day
+** `weekly` - Indicates documents could be changed every weekly
+** `monthly` - Indicates documents could be changed every monthly
+** `yearly` - Indicates documents could be changed every yearly
+** `never` - Indicates documents that are for archival more than realtime / active data
+* priority (optional) - **Hints** at how important a page is to be displayed when showing search results, this property expects a decimal number between 0.0 and 1.0
+
+# How do I fix this ?
+
+Ensure the schema of your page matches the standard as defined at [Sitemaps XML format](http://www.sitemaps.org/protocol.html), fixing any issues listed on a per case basis.
+
+# Resources
+
+* [Sitemaps XML format](http://www.sitemaps.org/protocol.html)
+* [What Content-Type value should I send for my XML sitemap?](http://stackoverflow.com/questions/3272534/what-content-type-value-should-i-send-for-my-xml-sitemap)

--- a/docs/sitemap.schema.md
+++ b/docs/sitemap.schema.md
@@ -1,8 +1,8 @@
-Sitemaps (although not that widely used anymore but still an valid standard) allow site owners to give search engines lists of urls that might be hard to find while doing a normal crawl of the website.
+Sitemaps (although not that widely used anymore but still a valid standard) allow site owners to give search engines lists of URLs that might be hard to find while doing a normal crawl of the website.
 
-These sitemaps must be a XML file on the root of the site, namely `/sitemap.xml` that conform to the standard laid out by [Sitemaps XML format](http://www.sitemaps.org/protocol.html). 
+These sitemaps must be an XML file on the root of the site, namely `/sitemap.xml` that conform to the standard laid out by [Sitemaps XML format](http://www.sitemaps.org/protocol.html). 
 
-Valid sitemaps would appear as follows (for a example):
+Valid sitemaps would appear as follows (for an example):
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/sitemap.schema.md
+++ b/docs/sitemap.schema.md
@@ -33,6 +33,7 @@ Valid sitemaps would appear as follows (for a example):
    </url>
 
 </urlset> 
+```
 
 with the following options, that are either required or optional:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = exports = [
   require('./rules/canonical'),
   require('./rules/canonical.link'),
   require('./rules/robots'),
+  require('./rules/sitemap'),
   require('./rules/protocol')
 
 ];

--- a/lib/rules/sitemap.js
+++ b/lib/rules/sitemap.js
@@ -7,16 +7,13 @@ const request       = require('request')
 const _             = require('underscore')
 const xml2js        = require('xml2js');
 
-// constant bots
-var KNOWNROBOTS = require('../../robots.json');
-
-// returns the robots txt based on the payload
+// returns the sitemap txt based on the payload
 var getSitemapContent = function(payload, options, fn) {
 
   // get the data
   var data      = payload.getData();
 
-  // is robots defined ... ?
+  // is sitemap defined ... ?
   if(data.testingSitemap) return fn(null, data.testingSitemapResponse, data.testingSitemap);
 
   // do the actual request
@@ -57,7 +54,7 @@ module.exports = exports = function(payload, fn) {
   // get the data
   var data    = payload.getData()
 
-  // go get the robots file
+  // go get the sitemap file
   var uri     = url.parse(data.url);
 
   // create the actual target
@@ -85,7 +82,7 @@ module.exports = exports = function(payload, fn) {
 
   ];
 
-  // get the robots from site
+  // get the sitemap from site
   getSitemapContent(payload, {
 
     method:   'GET',
@@ -99,14 +96,14 @@ module.exports = exports = function(payload, fn) {
     if(err) {
 
       // output to log
-      payload.error('Problem checking the robots txt', err);
+      payload.error('Problem checking the sitemap txt', err);
 
       // finish
       return fn(null);
 
     }
 
-    // is robots not empty
+    // is sitemap not empty
     if(S(sitemapTxt).isEmpty() === true) {
 
       // done

--- a/lib/rules/sitemap.js
+++ b/lib/rules/sitemap.js
@@ -1,0 +1,496 @@
+// load in the required modules
+const cheerio       = require('cheerio')
+const url           = require('url')
+const S             = require('string')
+const async         = require('async')
+const request       = require('request')
+const _             = require('underscore')
+const xml2js        = require('xml2js');
+
+// constant bots
+var KNOWNROBOTS = require('../../robots.json');
+
+// returns the robots txt based on the payload
+var getSitemapContent = function(payload, options, fn) {
+
+  // get the data
+  var data      = payload.getData();
+
+  // is robots defined ... ?
+  if(data.testingSitemap) return fn(null, data.testingSitemapResponse, data.testingSitemap);
+
+  // do the actual request
+  request(options, function(err, response, body) {
+
+    // check for a error
+    if(err) {
+
+      // output
+      payload.error('Problem downloading the website sitemap.xml', err);
+
+      // return error
+      return fn(null, response, '');
+
+    }
+
+    // check if the response is 200
+    if((response || {}).statusCode !== 200) {
+
+      // debug
+      payload.debug('The response code from the sitemap.xml given was ' + ((response || {}).statusCode || 200));
+
+      // nope out of there
+      return fn(null, response, '');
+
+    }
+
+    // done
+    fn(null, response, body || '');
+
+  })
+
+};
+
+// expose the items
+module.exports = exports = function(payload, fn) {
+
+  // get the data
+  var data    = payload.getData()
+
+  // go get the robots file
+  var uri     = url.parse(data.url);
+
+  // create the actual target
+  var href    = url.format( _.extend({}, uri, {
+
+    pathname:     '/sitemap.xml',
+    search:       ''
+
+  }) );
+
+  // list of known properties
+  const knownProperties = [
+
+    'loc',
+    'lastmod',
+    'changefreq',
+    'priority'
+
+  ];
+
+  // list of required properties
+  const requiredProperties = [
+
+    'loc'
+
+  ];
+
+  // get the robots from site
+  getSitemapContent(payload, {
+
+    method:   'GET',
+    type:     'GET',
+    url:      href,
+    timeout:  5 * 1000
+
+  }, function(err, response, sitemapTxt) {
+
+    // check for a error
+    if(err) {
+
+      // output to log
+      payload.error('Problem checking the robots txt', err);
+
+      // finish
+      return fn(null);
+
+    }
+
+    // is robots not empty
+    if(S(sitemapTxt).isEmpty() === true) {
+
+      // done
+      return fn(null);
+
+    }
+
+    // check if the server handled the error
+    if((response || {}).statusCode !== 200) {
+
+      // all good
+      return fn(null);
+
+    }
+
+    // then we check the content of the sitemap
+    var contentType = S( ((response || {}).headers || {})['content-type'] || '' ).trim().s.toLowerCase();
+
+    // split the sitemap lines
+    var lines = (sitemapTxt || '').split('\n');
+
+    // did we find the content type ?
+    if(contentType.indexOf('application/xml') === -1 && 
+        contentType.indexOf('text/xml') === -1) {
+
+      // bad return format ...
+      payload.addRule({
+
+        type:         'error',
+        key:          'sitemap.format',
+        message:      'Defined Sitemap must return XML'
+
+      }, {
+
+        message:      'The sitemap at $, returned $ instead of HTML',
+        display:      'code',
+        identifiers:  [ href, contentType ],
+        code:         {
+
+          text:     lines.slice(0, 5),
+          start:    0,
+          end:      lines.slice(0, 5).length + 1,
+          subject:  0
+
+        }
+
+      });
+
+      // done
+      return fn(null);
+
+    }
+
+    // else we try to parse the response
+    xml2js.parseString(sitemapTxt, function (err, result) {
+
+      // generic details of the rule itself, 
+      // occurrences give more details to the rule itself
+      const rulePrologMeta = {
+
+        key:      'sitemap.prolog',
+        message:  'Missing or misconfigured prolog defined for sitemap',
+        type:     'error'
+
+      };
+
+
+      // gets the first line of the file
+      var firstLine = S(S(sitemapTxt).trim().s.toLowerCase().split('\n')[0] || '').trim().s;
+
+      // the file must start with the encoding
+      if( firstLine.startsWith('<?xml') === false ) {
+
+        // add the occurence
+        payload.addRule(rulePrologMeta, {
+
+          message:      'Sitemap must start with $ as part of $',
+          identifiers:  [ '<?xml', '<?xml version="1.0" encoding="UTF-8" ?>' ],
+          file:         href,
+          display:      'code',
+          code:         {
+
+            text:       lines.slice(0, 10),
+            start:      0,
+            end:        lines.slice(0, 10).length + 1,
+            subject:    0
+
+          }
+
+        });
+
+      }
+
+      // the file must start with the encoding
+      if( firstLine.indexOf('version="1.0"') === -1 ) {
+
+        // add the occurence
+        payload.addRule(rulePrologMeta, {
+
+          message:      'Sitemap prolog must contain $ somewhere between $ and $ on the first line',
+          identifiers:  [ 'version="1.0"', '<?xml', '?>' ],
+          file:         href,
+          display:      'code',
+          code:         {
+
+            text:       lines.slice(0, 10),
+            start:      0,
+            end:        lines.slice(0, 10).length + 1,
+            subject:    0
+
+          }
+
+        });
+
+      }
+
+      // the file must start with the encoding
+      if( firstLine.indexOf('encoding="') === -1 ) {
+
+        // add the occurence
+        payload.addRule(rulePrologMeta, {
+
+          message:      'Sitemap prolog must contain the encoding (like $) somewhere between $ and $ on the first line',
+          identifiers:  [ 'encoding="UTF-8"', '<?xml', '?>' ],
+          file:         href,
+          display:      'code',
+          code:         {
+
+            text:       lines.slice(0, 10),
+            start:      0,
+            end:        lines.slice(0, 10).length + 1,
+            subject:    0
+
+          }
+
+        });
+
+      }
+
+      // prolog must end with ?>
+      if( S(firstLine).endsWith('?>') === false ) {
+
+        // add the occurence
+        payload.addRule(rulePrologMeta, {
+
+          message:      'Sitemap prolog have $ as a closing tag',
+          identifiers:  [ '?>' ],
+          file:         href,
+          display:      'code',
+          code:         {
+
+            text:       lines.slice(0, 10),
+            start:      0,
+            end:        lines.slice(0, 10).length + 1,
+            subject:    0
+
+          }
+
+        });
+
+      }
+
+      // we got a error O_O, so this was not valid XML ...
+      if(err) {
+
+        // register that we are unable to parse this XML ...
+        payload.addRule({
+
+          type:         'critical',
+          key:          'sitemap.invalid',
+          message:      'Unable to parse defined sitemap'
+
+        }, {
+
+          message:      'Unable to parse the sitemap at $ as XML, indicating invalid XML',
+          file:         href,
+          display:      'code',
+          identifiers:  [ href, contentType ],
+          code:         {
+
+            text:     lines.slice(0, 20),
+            start:    0,
+            end:      lines.slice(0, 20).length + 1,
+            subject:  0
+
+          }
+
+        });
+
+        // done
+        return fn(null);
+
+      }
+
+      // check if blank ... ?
+      if(result === null || 
+          result === undefined || 
+            S(sitemapTxt).isEmpty() === true) {
+
+        // add the rule
+        payload.addRule({
+
+          key:          'sitemap.empty',
+          message:      'Defined sitemap was empty',
+          type:         'error'
+
+        }, {
+
+          message:      'Sitemap at $ should have some content',
+          identifiers:  [ '/sitemap.xml' ],
+          file:         href,
+          display:      'code',
+          code:         {
+
+            text:       lines.slice(0, 10),
+            start:      0,
+            end:        lines.slice(0, 10).length + 1,
+            subject:    0
+
+          }
+
+        });
+
+        // stop here then 
+        return fn(null);
+
+      }
+
+      // get the keys of the root
+      var rootKeys = _.keys(result);
+
+      // constant meta for the schema output
+      const ruleSchemaMeta = {
+
+        key:          'sitemap.schema',
+        message:      'Defined sitemap contains incorrect schema',
+        type:         'error'
+
+      };
+
+      // there should only be one key ...
+      if(rootKeys.length !== 1 || 
+        (rootKeys[0] || '').toLowerCase() != 'urlset') {
+
+          // add the rule
+          payload.addRule(ruleSchemaMeta, {
+
+            message:      'Sitemap should contain only one root node of $',
+            identifiers:  [ '<urlset>' ],
+            file:         href,
+            display:      'code',
+            code:         {
+
+              text:       lines.slice(0, 10),
+              start:      0,
+              end:        lines.slice(0, 10).length + 1,
+              subject:    0
+
+            }
+
+          });
+
+      }
+
+      // check if the root node is defined
+      if( result['urlset'] ) {
+
+        // yes we do :), so check if we have any weird keys
+        var childKeys = _.keys(result['urlset']);
+
+        // check if any of the keys don't match "<url>"
+        var unknownChildren = _.filter(childKeys || [], function(child) { 
+
+          return (child || '').toLowerCase() != 'url' 
+
+        });
+
+        // for each add a broken rule
+        for(var i = 0; i < childKeys.length; i++) {
+
+          // check if not url
+          if( (childKeys[i] || '').toLowerCase() != 'url' ) {
+
+            // add the rule
+            payload.addRule(ruleSchemaMeta, {
+
+              message:      'The root node of the site ($) should contain only $ nodes',
+              identifiers:  [ '<urlset>', '<url>' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 20),
+                start:      0,
+                end:        lines.slice(0, 20).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+          }
+
+        }
+
+      }
+
+      // check if the root node is defined
+      if( result['urlset'] ) {
+
+        // yes we do :), so check if we have any weird keys
+        var nodes = (result['urlset'] || {})['url'] || [];
+
+        // for each add a broken rule
+        for(var i = 0; i < nodes.length; i++) {
+
+          // get the nodes keys
+          var childKeys = _.keys(nodes[i]);
+
+          // check if all the properties are known 
+          for(var a = 0; a < childKeys.length; a++) {
+
+            // check if this is a known property ...
+            if( knownProperties.indexOf( (childKeys[a] || '').toLowerCase() ) === -1 ) {
+
+              // add the rule
+              payload.addRule(ruleSchemaMeta, {
+
+                message:      'Unknown property $ given for $ node',
+                identifiers:  [ childKeys[a], '<url>' ],
+                file:         href,
+                display:      'code',
+                code:         {
+
+                  text:       lines.slice(0, 20),
+                  start:      0,
+                  end:        lines.slice(0, 20).length + 1,
+                  subject:    0
+
+                }
+
+              });
+
+            }
+
+          }
+
+          // check if any of the required properties are missing ...
+          for(var a = 0; a < requiredProperties.length; a++) {
+
+            // check if this is a known property ...
+            if( childKeys.indexOf( requiredProperties ) === -1 ) {
+
+              // add the rule
+              payload.addRule(ruleSchemaMeta, {
+
+                message:      'Required property $ not specified for $ child node',
+                identifiers:  [ '<loc>', '<url>' ],
+                file:         href,
+                display:      'code',
+                code:         {
+
+                  text:       lines.slice(0, 20),
+                  start:      0,
+                  end:        lines.slice(0, 20).length + 1,
+                  subject:    0
+
+                }
+
+              });
+
+            }
+
+          }
+
+        }
+
+      }
+
+      // done
+      fn(null);
+
+    });
+
+  });
+
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "tldjs": "^1.6.2",
     "ua-parser-js": "^0.7.9",
     "underscore": "^1.8.3",
-    "winston": "^1.0.1"
+    "winston": "^1.0.1",
+    "xml2js": "^0.4.17"
   },
   "devDependencies": {
     "mocha": "^2.1.0"

--- a/test/sitemap.js
+++ b/test/sitemap.js
@@ -1,0 +1,867 @@
+// modules
+const assert        = require('assert');
+const _             = require('underscore');
+const fs            = require('fs');
+const passmarked    = require('passmarked');
+const testFunc      = require('../lib/rules/sitemap');
+
+// handle the settings
+describe('sitemap', function() {
+
+  // add the test for the robot
+  it('Should not return a error if the /sitemap.xml url returned anything else than a 200', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 404
+
+      },
+      testingSitemap:  [
+
+        ' '
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check if we found it
+      if(rules.length > 0)
+        assert.fail('Was not expecting a rule to be returned');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the sitemap returned as text/html', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/html'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        'user-agent: *'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.format';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should not return a error if the sitemap returned as application/xml', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'application/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        'user-agent: *'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.format';
+
+      });
+
+      // check if we found it
+      if(rule)
+        assert.fail('Was not expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should not return a error if the sitemap returned as text/xml', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        'user-agent: *'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.format';
+
+      });
+
+      // check if we found it
+      if(rule)
+        assert.fail('Was not expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should not return a error if the prolog is correct - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(rule)
+        assert.fail('Was not expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should not return a error if the prolog is correct, even with spaces - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '        <?xml version="1.0" encoding="UTF-8" ?>     '
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(rule)
+        assert.fail('Was not expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the prolog is missing <?xml at the start', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        'version="1.0" <?xml encoding="UTF-8" ?>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the prolog is missing version="1.0" at the start', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml encoding="UTF-8" ?>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the prolog is missing encoding=', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" ?>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the prolog is missing the end tag - ?>', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8"'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.prolog';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should not return a error if the XML is able to parse', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<urlset>',
+        '</urlset>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.invalid';
+
+      });
+
+      // check if we found it
+      if(rule)
+        assert.fail('Was not expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the XML is not able to parse', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<urlset>',
+        '<urlset>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.invalid';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if the first node is not "urlset"', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<test hello="world">',
+        '</test>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.schema';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if any of the children of "urlset" are not "url"', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<urlset>',
+        '<test>',
+        '<loc></loc>',
+        '</test>',
+        '</urlset>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.schema';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if no "<loc" is given', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<urlset>',
+        '<url>',
+        '</url>',
+        '</urlset>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.schema';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // add the test for the robot
+  it('Should return a error if a unknown property is given', function(done) {
+
+    // handle the payload
+    var payload = passmarked.createPayload({
+
+      testingSitemapResponse: {
+
+        statusCode: 200,
+        headers: {
+
+          'content-type': 'text/xml;charset=utf-8'
+
+        }
+
+      },
+      testingSitemap:  [
+
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<urlset>',
+        '<url>',
+        '<test></test>',
+        '</url>',
+        '</urlset>'
+
+      ].join('\n'),
+      url:            'https://example.com'
+
+    }, null, '');
+
+    // run the rules
+    testFunc(payload, function(err) {
+
+      // check for a error
+      if(err)
+        assert.fail('Was not expecting a error');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check
+      var rule = _.find(rules, function(item) {
+
+        return item.key == 'sitemap.schema';
+
+      });
+
+      // check if we found it
+      if(!rule)
+        assert.fail('Was expecting a rule to return');
+
+      // done
+      done();
+
+    });
+
+  });
+
+});

--- a/test/sitemap.js
+++ b/test/sitemap.js
@@ -8,8 +8,8 @@ const testFunc      = require('../lib/rules/sitemap');
 // handle the settings
 describe('sitemap', function() {
 
-  // add the test for the robot
-  it('Should not return a error if the /sitemap.xml url returned anything else than a 200', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the /sitemap.xml url returned anything else than a 200', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -31,9 +31,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -49,8 +49,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the sitemap returned as text/html', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the sitemap returned as text/html', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -77,9 +77,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -102,8 +102,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should not return a error if the sitemap returned as application/xml', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the sitemap returned as application/xml', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -130,9 +130,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -155,8 +155,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should not return a error if the sitemap returned as text/xml', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the sitemap returned as text/xml', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -183,9 +183,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -208,8 +208,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should not return a error if the prolog is correct - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the prolog is correct - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -236,9 +236,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -261,8 +261,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should not return a error if the prolog is correct, even with spaces - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the prolog is correct, even with spaces - <?xml version="1.0" encoding="UTF-8" ?>', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -289,9 +289,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -314,8 +314,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the prolog is missing <?xml at the start', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the prolog is missing <?xml at the start', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -342,9 +342,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -367,8 +367,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the prolog is missing version="1.0" at the start', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the prolog is missing version="1.0" at the start', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -395,9 +395,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -420,8 +420,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the prolog is missing encoding=', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the prolog is missing encoding=', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -448,9 +448,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -473,8 +473,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the prolog is missing the end tag - ?>', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the prolog is missing the end tag - ?>', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -501,9 +501,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -526,8 +526,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should not return a error if the XML is able to parse', function(done) {
+  // add the test for the sitemap
+  it('Should not return an error if the XML is able to parse', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -556,9 +556,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -581,8 +581,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the XML is not able to parse', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the XML is not able to parse', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -611,9 +611,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -636,8 +636,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if the first node is not "urlset"', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if the first node is not "urlset"', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -666,9 +666,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -691,8 +691,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if any of the children of "urlset" are not "url"', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if any of the children of "urlset" are not "url"', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -724,9 +724,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -749,8 +749,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if no "<loc" is given', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if no "<loc" is given', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -781,9 +781,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();
@@ -806,8 +806,8 @@ describe('sitemap', function() {
 
   });
 
-  // add the test for the robot
-  it('Should return a error if a unknown property is given', function(done) {
+  // add the test for the sitemap
+  it('Should return an error if a unknown property is given', function(done) {
 
     // handle the payload
     var payload = passmarked.createPayload({
@@ -839,9 +839,9 @@ describe('sitemap', function() {
     // run the rules
     testFunc(payload, function(err) {
 
-      // check for a error
+      // check for an error
       if(err)
-        assert.fail('Was not expecting a error');
+        assert.fail('Was not expecting an error');
 
       // get the rules
       var rules = payload.getRules();


### PR DESCRIPTION
Does a check for the sitemap as well as validation if present. We're not too worried about sitemaps but if one is defined it should be in the right format, and if none are present the url /sitemap.xml should **not** return a catchall page that renders the homepage or something.

Consider this the first version, it currently checks:
- If the sitemap.xml defined is `text/xml` or `application/text` which should stop any HTML pages through
- If the sitemap.xml defined is even parseable as XML ?
- If the sitemap.xml has a correctly defined prolog and all the required sections as part of the checks
- If the sitemap.xml conforms to the spec and does not have any unknown properties
- If the sitemap.xml conforms and has all the required properties in the nodes

Going to see about adding actual value validation for each of the properties as they all have their own specs for how the data should be presented
