### PR TITLE
Release v1.0.9

### DIFF
--- a/lib/rules/alias.js
+++ b/lib/rules/alias.js
@@ -35,7 +35,8 @@ var doRequest = function(payload, options, fn) {
 
     session:    data.session,
     url:        options.url,
-    type:       'GET'
+    type:       'GET',
+    kill:       true
 
   }, fn);
 

--- a/lib/rules/description.js
+++ b/lib/rules/description.js
@@ -47,9 +47,15 @@ module.exports = exports = function(payload, fn) {
       // no titles defined ...
       payload.addRule({
 
-        type:     'error',
-        key:      'description.missing',
-        message:  'No document description tag was found in the head of the page'
+        type:         'error',
+        key:          'description.missing',
+        message:      'No document description tag was found in the head of the page'
+
+      }, {
+
+        display:      'url',
+        message:      'Missing description meta tag on $',
+        idenfitiers:  [ data.url ]
 
       })
 

--- a/lib/rules/homepage.js
+++ b/lib/rules/homepage.js
@@ -70,7 +70,7 @@ module.exports = exports = function(payload, fn) {
   if(VARIATIONS.indexOf( pathname ) === -1) {
 
     // debugging
-    payload.debug('Skipping as ' + uri.pathname + ' != /')
+    payload.debug('homepage', 'Skipping as ' + uri.pathname + ' != /')
 
     // finish strong
     return fn(null);
@@ -86,7 +86,7 @@ module.exports = exports = function(payload, fn) {
     if(variation === pathname) {
 
       // debugging
-      payload.debug('Skipping as ' + variation + ' matches the current page - ' + pathname);
+      payload.debug('homepage', 'Skipping as ' + variation + ' matches the current page - ' + pathname);
 
       // done
       return cb(null);

--- a/lib/rules/sitemap.js
+++ b/lib/rules/sitemap.js
@@ -88,15 +88,17 @@ module.exports = exports = function(payload, fn) {
 
   ];
 
-  // get the sitemap from site
-  getSitemapContent(payload, {
+  // the subject address
+  const subjectAddress = {
 
-    method:   'GET',
-    type:     'GET',
-    url:      href,
-    timeout:  5 * 1000
+    key:      'seo',
+    rule:     'sitemap',
+    subject:  href
 
-  }, function(err, response, sitemapTxt) {
+  };
+
+  // check if not checked already for this site
+  payload.isMentioned(subjectAddress, function(err, isMentioned) {
 
     // check for a error
     if(err) {
@@ -110,271 +112,307 @@ module.exports = exports = function(payload, fn) {
     }
 
     // is sitemap not empty
-    if(S(sitemapTxt).isEmpty() === true) {
+    if(isMentioned === true) {
 
       // done
       return fn(null);
 
     }
 
-    // check if the server handled the error
-    if((response || {}).statusCode !== 200) {
+    // else mention and do the check
+    payload.mention(subjectAddress, function() {
 
-      // all good
-      return fn(null);
+      // get the sitemap from site
+      getSitemapContent(payload, {
 
-    }
+        method:   'GET',
+        type:     'GET',
+        url:      href,
+        timeout:  5 * 1000
 
-    // then we check the content of the sitemap
-    var contentType = S( ((response || {}).headers || {})['content-type'] || '' ).trim().s.toLowerCase();
+      }, function(err, response, sitemapTxt) {
 
-    // split the sitemap lines
-    var lines = (sitemapTxt || '').split('\n');
+        // check for a error
+        if(err) {
 
-    // did we find the content type ?
-    if(contentType.indexOf('application/xml') === -1 && 
-        contentType.indexOf('text/xml') === -1) {
+          // output to log
+          payload.error('Problem checking the sitemap txt', err);
 
-      // bad return format ...
-      payload.addRule({
-
-        type:         'error',
-        key:          'sitemap.format',
-        message:      'Defined Sitemap must return XML'
-
-      }, {
-
-        message:      'The sitemap at $, returned $ instead of XML',
-        display:      'code',
-        identifiers:  [ href, contentType ],
-        code:         {
-
-          text:     lines.slice(0, 5),
-          start:    0,
-          end:      lines.slice(0, 5).length + 1,
-          subject:  0
+          // finish
+          return fn(null);
 
         }
 
-      });
+        // is sitemap not empty
+        if(S(sitemapTxt).isEmpty() === true) {
 
-      // done
-      return fn(null);
+          // done
+          return fn(null);
 
-    }
+        }
 
-    // else we try to parse the response
-    xml2js.parseString(sitemapTxt, function (err, result) {
+        // check if the server handled the error
+        if((response || {}).statusCode !== 200) {
 
-      // generic details of the rule itself, 
-      // occurrences give more details to the rule itself
-      const rulePrologMeta = {
+          // all good
+          return fn(null);
 
-        key:      'sitemap.prolog',
-        message:  'Missing or misconfigured prolog defined for sitemap',
-        type:     'error'
+        }
 
-      };
+        // then we check the content of the sitemap
+        var contentType = S( ((response || {}).headers || {})['content-type'] || '' ).trim().s.toLowerCase();
 
-      // gets the first line of the file
-      var firstLine = S(S(sitemapTxt).trim().s.toLowerCase().split('\n')[0] || '').trim().s;
+        // split the sitemap lines
+        var lines = (sitemapTxt || '').split('\n');
 
-      // the file must start with the encoding
-      if( firstLine.startsWith('<?xml') === false ) {
+        // did we find the content type ?
+        if(contentType.indexOf('application/xml') === -1 && 
+            contentType.indexOf('text/xml') === -1) {
 
-        // add the occurence
-        payload.addRule(rulePrologMeta, {
+          // bad return format ...
+          payload.addRule({
 
-          message:      'Sitemap must start with $ as part of $',
-          identifiers:  [ '<?xml', '<?xml version="1.0" encoding="UTF-8" ?>' ],
-          file:         href,
-          display:      'code',
-          code:         {
+            type:         'error',
+            key:          'sitemap.format',
+            message:      'Defined Sitemap must return XML'
 
-            text:       lines.slice(0, 10),
-            start:      0,
-            end:        lines.slice(0, 10).length + 1,
-            subject:    0
+          }, {
 
-          }
-
-        });
-
-      }
-
-      // the file must start with the encoding
-      if( firstLine.indexOf('version="1.0"') === -1 ) {
-
-        // add the occurence
-        payload.addRule(rulePrologMeta, {
-
-          message:      'Sitemap prolog must contain $ somewhere between $ and $ on the first line',
-          identifiers:  [ 'version="1.0"', '<?xml', '?>' ],
-          file:         href,
-          display:      'code',
-          code:         {
-
-            text:       lines.slice(0, 10),
-            start:      0,
-            end:        lines.slice(0, 10).length + 1,
-            subject:    0
-
-          }
-
-        });
-
-      }
-
-      // the file must start with the encoding
-      if( firstLine.indexOf('encoding="') === -1 ) {
-
-        // add the occurence
-        payload.addRule(rulePrologMeta, {
-
-          message:      'Sitemap prolog must contain the encoding (like $) somewhere between $ and $ on the first line',
-          identifiers:  [ 'encoding="UTF-8"', '<?xml', '?>' ],
-          file:         href,
-          display:      'code',
-          code:         {
-
-            text:       lines.slice(0, 10),
-            start:      0,
-            end:        lines.slice(0, 10).length + 1,
-            subject:    0
-
-          }
-
-        });
-
-      }
-
-      // prolog must end with ?>
-      if( S(firstLine).endsWith('?>') === false ) {
-
-        // add the occurence
-        payload.addRule(rulePrologMeta, {
-
-          message:      'Sitemap prolog have $ as a closing tag',
-          identifiers:  [ '?>' ],
-          file:         href,
-          display:      'code',
-          code:         {
-
-            text:       lines.slice(0, 10),
-            start:      0,
-            end:        lines.slice(0, 10).length + 1,
-            subject:    0
-
-          }
-
-        });
-
-      }
-
-      // we got a error O_O, so this was not valid XML ...
-      if(err) {
-
-        // register that we are unable to parse this XML ...
-        payload.addRule({
-
-          type:         'critical',
-          key:          'sitemap.invalid',
-          message:      'Unable to parse defined sitemap'
-
-        }, {
-
-          message:      'Unable to parse the sitemap at $ as XML, indicating invalid XML',
-          file:         href,
-          display:      'code',
-          identifiers:  [ href, contentType ],
-          code:         {
-
-            text:     lines.slice(0, 20),
-            start:    0,
-            end:      lines.slice(0, 20).length + 1,
-            subject:  0
-
-          }
-
-        });
-
-        // done
-        return fn(null);
-
-      }
-
-      // check if blank ... ?
-      if(result === null || 
-          result === undefined || 
-            S(sitemapTxt).isEmpty() === true) {
-
-        // add the rule
-        payload.addRule({
-
-          key:          'sitemap.empty',
-          message:      'Defined sitemap was empty',
-          type:         'error'
-
-        }, {
-
-          message:      'Sitemap at $ should have some content',
-          identifiers:  [ '/sitemap.xml' ],
-          file:         href,
-          display:      'code',
-          code:         {
-
-            text:       lines.slice(0, 10),
-            start:      0,
-            end:        lines.slice(0, 10).length + 1,
-            subject:    0
-
-          }
-
-        });
-
-        // stop here then 
-        return fn(null);
-
-      }
-
-      // get the keys of the root
-      var rootKeys = _.keys(result);
-
-      // constant meta for the schema output
-      const ruleSchemaMeta = {
-
-        key:          'sitemap.schema',
-        message:      'Defined sitemap contains incorrect schema',
-        type:         'error'
-
-      };
-
-      // there should only be one key ...
-      if(rootKeys.length !== 1 || 
-        (rootKeys[0] || '').toLowerCase() != 'urlset') {
-
-          // add the rule
-          payload.addRule(ruleSchemaMeta, {
-
-            message:      'Sitemap should contain only one root node of $',
-            identifiers:  [ '<urlset>' ],
-            file:         href,
+            message:      'The sitemap at $, returned $ instead of XML',
             display:      'code',
+            identifiers:  [ href, contentType ],
             code:         {
 
-              text:       lines.slice(0, 10),
-              start:      0,
-              end:        lines.slice(0, 10).length + 1,
-              subject:    0
+              text:     lines.slice(0, 5),
+              start:    0,
+              end:      lines.slice(0, 5).length + 1,
+              subject:  0
 
             }
 
           });
 
-      }
+          // done
+          return fn(null);
 
-      // done
-      setImmediate(fn, null);
+        }
+
+        // else we try to parse the response
+        xml2js.parseString(sitemapTxt, function (err, result) {
+
+          // generic details of the rule itself, 
+          // occurrences give more details to the rule itself
+          const rulePrologMeta = {
+
+            key:      'sitemap.prolog',
+            message:  'Missing or misconfigured prolog defined for sitemap',
+            type:     'error'
+
+          };
+
+          // gets the first line of the file
+          var firstLine = S(S(sitemapTxt).trim().s.toLowerCase().split('\n')[0] || '').trim().s;
+
+          // the file must start with the encoding
+          if( firstLine.startsWith('<?xml') === false ) {
+
+            // add the occurence
+            payload.addRule(rulePrologMeta, {
+
+              message:      'Sitemap must start with $ as part of $',
+              identifiers:  [ '<?xml', '<?xml version="1.0" encoding="UTF-8" ?>' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 10),
+                start:      0,
+                end:        lines.slice(0, 10).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+          }
+
+          // the file must start with the encoding
+          if( firstLine.indexOf('version="1.0"') === -1 ) {
+
+            // add the occurence
+            payload.addRule(rulePrologMeta, {
+
+              message:      'Sitemap prolog must contain $ somewhere between $ and $ on the first line',
+              identifiers:  [ 'version="1.0"', '<?xml', '?>' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 10),
+                start:      0,
+                end:        lines.slice(0, 10).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+          }
+
+          // the file must start with the encoding
+          if( firstLine.indexOf('encoding="') === -1 ) {
+
+            // add the occurence
+            payload.addRule(rulePrologMeta, {
+
+              message:      'Sitemap prolog must contain the encoding (like $) somewhere between $ and $ on the first line',
+              identifiers:  [ 'encoding="UTF-8"', '<?xml', '?>' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 10),
+                start:      0,
+                end:        lines.slice(0, 10).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+          }
+
+          // prolog must end with ?>
+          if( S(firstLine).endsWith('?>') === false ) {
+
+            // add the occurence
+            payload.addRule(rulePrologMeta, {
+
+              message:      'Sitemap prolog have $ as a closing tag',
+              identifiers:  [ '?>' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 10),
+                start:      0,
+                end:        lines.slice(0, 10).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+          }
+
+          // we got a error O_O, so this was not valid XML ...
+          if(err) {
+
+            // register that we are unable to parse this XML ...
+            payload.addRule({
+
+              type:         'critical',
+              key:          'sitemap.invalid',
+              message:      'Unable to parse defined sitemap'
+
+            }, {
+
+              message:      'Unable to parse the sitemap at $ as XML, indicating invalid XML',
+              file:         href,
+              display:      'code',
+              identifiers:  [ href, contentType ],
+              code:         {
+
+                text:     lines.slice(0, 20),
+                start:    0,
+                end:      lines.slice(0, 20).length + 1,
+                subject:  0
+
+              }
+
+            });
+
+            // done
+            return fn(null);
+
+          }
+
+          // check if blank ... ?
+          if(result === null || 
+              result === undefined || 
+                S(sitemapTxt).isEmpty() === true) {
+
+            // add the rule
+            payload.addRule({
+
+              key:          'sitemap.empty',
+              message:      'Defined sitemap was empty',
+              type:         'error'
+
+            }, {
+
+              message:      'Sitemap at $ should have some content',
+              identifiers:  [ '/sitemap.xml' ],
+              file:         href,
+              display:      'code',
+              code:         {
+
+                text:       lines.slice(0, 10),
+                start:      0,
+                end:        lines.slice(0, 10).length + 1,
+                subject:    0
+
+              }
+
+            });
+
+            // stop here then 
+            return fn(null);
+
+          }
+
+          // get the keys of the root
+          var rootKeys = _.keys(result);
+
+          // constant meta for the schema output
+          const ruleSchemaMeta = {
+
+            key:          'sitemap.schema',
+            message:      'Defined sitemap contains incorrect schema',
+            type:         'error'
+
+          };
+
+          // there should only be one key ...
+          if(rootKeys.length !== 1 || 
+            (rootKeys[0] || '').toLowerCase() != 'urlset') {
+
+              // add the rule
+              payload.addRule(ruleSchemaMeta, {
+
+                message:      'Sitemap should contain only one root node of $',
+                identifiers:  [ '<urlset>' ],
+                file:         href,
+                display:      'code',
+                code:         {
+
+                  text:       lines.slice(0, 10),
+                  start:      0,
+                  end:        lines.slice(0, 10).length + 1,
+                  subject:    0
+
+                }
+
+              });
+
+          }
+
+          // done
+          setImmediate(fn, null);
+
+        });
+
+      });
 
     });
 

--- a/lib/rules/ssl.js
+++ b/lib/rules/ssl.js
@@ -10,21 +10,69 @@ module.exports = exports = function(payload, fn) {
   // get the url
   var data = payload.getData();
 
+  // the subject address
+  const subjectAddress = {
+
+    key:      'seo',
+    rule:     'ssl',
+    subject:  S(data.url || '').slugify().s
+
+  };
+
   // check if the url is https
   if(S(data.url || '').trim().s.toLowerCase().indexOf('https://') !== 0) {
 
-    // show the error
-    payload.addRule({
+    // check if not checked already for this site
+    payload.isMentioned(subjectAddress, function(err, isMentioned) {
 
-      key:        'ssl',
-      type:       'notice',
-      message:    'HTTPS not enabled'
+      // check for a error
+      if(err) {
+
+        // output to log
+        payload.error('Problem checking the sitemap txt', err);
+
+        // finish
+        return fn(null);
+
+      }
+
+      // is sitemap not empty
+      if(isMentioned === true) {
+
+        // done
+        return fn(null);
+
+      }
+
+      payload.mention(subjectAddress, function() {
+
+        // show the error
+        payload.addRule({
+
+          key:          'ssl',
+          type:         'warning',
+          message:      'HTTPS not enabled'
+
+        }, {
+
+          display:      'url',
+          message:      '$ was served over $',
+          identifiers:  [ data.url, 'HTTP' ]
+
+        });
+
+        // done
+        fn(null);
+
+      });
 
     });
 
-  }
+  } else {
 
-  // done ... ?
-  fn(null)
+    // done ... ?
+    fn(null)
+
+  }
 
 };

--- a/lib/rules/title.js
+++ b/lib/rules/title.js
@@ -47,9 +47,15 @@ module.exports = exports = function(payload, fn) {
       // no titles defined ...
       payload.addRule({
 
-        type:     'error',
-        key:      'title.missing',
-        message:  'No document <title> tag was found in the head of the page'
+        type:         'error',
+        key:          'title.missing',
+        message:      'No document <title> tag was found in the head of the page'
+
+      }, {
+
+        display:      'url',
+        message:      'Missing title tag on $',
+        idenfitiers:  [ data.url ]
 
       })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/seo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Rules related to checking for any SEO issues on the page given",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Maintenance release that marks rules as only taking place once for the entire session using the mention framework in place now after 2 releases.

Along with a few small changes to rather:

* kill the `HEAD` request (not that we need to, but why now).
* Added occurrences to the title and description