### PR TITLE
Enforced that titles are only checked in <head>

### DIFF
--- a/lib/rules/title.js
+++ b/lib/rules/title.js
@@ -48,7 +48,7 @@ module.exports = exports = function(payload, fn) {
     var $ = cheerio.load(content);
 
     // get the count of tags
-    var headCount = $('title').length || 0;
+    var headCount = $('head > title').length || 0;
 
     // check for title tags
     if(headCount === 0) {
@@ -83,7 +83,7 @@ module.exports = exports = function(payload, fn) {
     var lines = content.split('\n');
 
     // loop all the title tags in the head
-    $('title').each(function(index, elem) {
+    $('head > title').each(function(index, elem) {
 
       // local reference
       var parentTag   = ((($(elem).parent() || {})['0'] || {}).name || '').toLowerCase();

--- a/test/title.js
+++ b/test/title.js
@@ -255,45 +255,4 @@ describe('title', function() {
 
   });
 
-  // handle the error output
-  it('should give a error if the <title> is not in <head>', function(done) {
-
-    // read in the html sample
-    var content = fs.readFileSync('./samples/title.location.html').toString();
-
-    // handle the payload
-    var payload = passmarked.createPayload({
-
-      url: 'example.com'
-
-    }, null, content.toString())
-
-    // run the rules
-    testFunc(payload, function(err) {
-
-      // check for a error
-      if(err) 
-        assert.fail('Was not expecting a error');
-
-      // get the rules
-      var rules = payload.getRules()
-
-      // check
-      var rule = _.find(rules, function(item) {
-
-        return item.key == 'title.location';
-
-      });
-
-      // check if we found it
-      if(!rule)
-        assert.fail('Was expecting a error');
-
-      // done
-      done();
-
-    });
-
-  });
-
 });


### PR DESCRIPTION
Enforced that titles are only checked in the head as it's still valid HTML if under SVG, and titles under <body> and still semantically correct even if unintended. We are already showing message for non-defined titles so I don't see a problem here if the title is accidentally put just inside the body.