### PR TITLE
prevent request from following redirect when testing for common alias

### DIFF
--- a/lib/rules/homepage.js
+++ b/lib/rules/homepage.js
@@ -44,13 +44,7 @@ var doRequest = function(payload, options, fn) {
     }, '');
 
   // check if we are not running 2 versions of the same page
-  payload.doRequest({
-
-    url:      options.url,
-    type:     'GET',
-    session:  data.session
-
-  }, fn);
+  payload.doRequest(options, fn);
 
 };
 
@@ -111,7 +105,12 @@ module.exports = exports = function(payload, fn) {
     // do the request
     doRequest(payload, {
 
-      url:      href
+      url:     href,
+      type:    'GET',
+      session: data.session,
+      options: {
+        followRedirect: false,
+      }
 
     }, function(err, response) {
 


### PR DESCRIPTION
* move all options for acutal `payload.doRequest()` to internal func call
* just pass options to `payload.doRequest()`
* add option flag `followRedirect` and set it to `false`